### PR TITLE
Automate Pages deployment with generated 20MB binary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Build and deploy site
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build site
+        run: |
+          mkdir -p public/downloads
+          cp index.html public/
+          cp CNAME public/
+          touch public/.nojekyll
+          head -c 20971520 /dev/urandom > public/downloads/1984-20MB.bin
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages

--- a/index.html
+++ b/index.html
@@ -1,12 +1,9 @@
 <!doctype html>
 <html lang="en-GB">
 <meta charset="utf-8">
-<title>Big Brother is watching you</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<body style="margin:0;font:16px system-ui;line-height:1.4;background:#fff;color:#111">
-  <main style="max-width:680px;margin:8vh auto;padding:16px">
-    <h1 style="margin:0 0 12px">Thought Police check</h1>
-    <p>Who controls the traffic controls our lives</p>
-  </main>
-</body>
+<title>Thought Police check</title>
+<main style="font:16px system-ui;margin:10vh auto;max-width:680px;padding:16px">
+<h1>Thought Police check</h1>
+<p>Who controls the LAN controls the our traffic.</p>
+</main>
 </html>


### PR DESCRIPTION
## Summary
- add `.nojekyll` to allow raw file serving on Pages
- replace `index.html` with minimal thought-police message
- add workflow to build and deploy a 20MB random binary file to `gh-pages`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aa62faec64832db7ef4bffa029ac4d